### PR TITLE
Fix documentation errors across multiple files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ dotnet publish src/Familiar.Host -c Release -o /opt/familiar
 
 - **Familiar.Host** - ASP.NET Core web server (port 8080), entry point in `Program.cs`
 - **Familiar.Audio** - ALSA audio playback/capture, Voice Activity Detection (VAD)
-- **Familiar.Tts** - Text-to-speech via espeak-ng subprocess
+- **Familiar.Tts** - Text-to-speech via espeak subprocess
 - **Familiar.Meshtastic** - LoRa mesh networking with protobuf protocol over serial
 - **Familiar.Camera** - Pi Camera Module 3 support (Pi 5 only)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Raspberry Pi-based communication system for cosplay handlers to communicate wi
 
 ## Overview
 
-Familiar Firmware enables seamless one-way audio communication from a handler's phone to a speaker/earpiece worn by a cosplayer. This is particularly useful for:
+Familiar Firmware enables seamless two-way audio communication between cosplay handlers (via phone) and cosplayers (via Pi device). This is particularly useful for:
 
 - Guiding cosplayers through crowded convention spaces
 - Providing cues during performances or photo ops
@@ -101,11 +101,11 @@ dotnet run --project src/Familiar.Host
 ```
 familiar-firmware/
 ├── src/
-│   ├── Familiar.Host/         # Main application host
+│   ├── Familiar.Host/         # Main application host (includes web interface)
 │   ├── Familiar.Audio/        # Audio processing and playback
-│   ├── Familiar.Web/          # Web interface and API
 │   ├── Familiar.Meshtastic/   # Meshtastic integration
-│   └── Familiar.Tts/          # Text-to-speech engine
+│   ├── Familiar.Tts/          # Text-to-speech engine
+│   └── Familiar.Camera/       # Camera support (Pi 5 only)
 ├── web/                       # Frontend assets (HTML/JS/CSS)
 ├── config/                    # Configuration files
 ├── scripts/                   # Setup and utility scripts
@@ -115,7 +115,7 @@ familiar-firmware/
 
 ## Configuration
 
-Edit `config/appsettings.json` to customize:
+Edit `src/Familiar.Host/appsettings.json` to customize:
 
 ```json
 {

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,10 +111,10 @@
 - [ ] Add Polly for retry policies
 
 ### Milestone 4.2: Security
-- [ ] Add JWT authentication to web interface
+- [x] Add JWT authentication to web interface
 - [ ] Implement HTTPS with Kestrel
 - [ ] Secure Meshtastic channel encryption
-- [ ] Add rate limiting middleware
+- [x] Add rate limiting middleware
 - [ ] Security audit
 
 ### Milestone 4.3: User Experience

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -1110,7 +1110,7 @@ talkBtn.addEventListener('touchend', () => client.stopTalking());
   "Kestrel": {
     "Endpoints": {
       "Http": {
-        "Url": "http://0.0.0.0:80"
+        "Url": "http://0.0.0.0:8080"
       },
       "Https": {
         "Url": "https://0.0.0.0:443",
@@ -1349,7 +1349,7 @@ Restart=always
 RestartSec=10
 User=familiar
 Environment=DOTNET_ENVIRONMENT=Production
-Environment=ASPNETCORE_URLS=http://0.0.0.0:80;https://0.0.0.0:443
+Environment=ASPNETCORE_URLS=http://0.0.0.0:8080;https://0.0.0.0:443
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- README.md: Change "one-way" to "two-way" audio (matches actual capability)
- README.md: Remove non-existent Familiar.Web, add Familiar.Camera
- README.md: Fix config path from config/ to src/Familiar.Host/
- TECHNICAL.md: Fix port 80 to 8080 (matches actual appsettings.json)
- ROADMAP.md: Mark JWT auth and rate limiting as complete
- CLAUDE.md: Change espeak-ng to espeak (matches actual config)

https://claude.ai/code/session_01KY5HARU3KGsSXXEcQsYiAp